### PR TITLE
docs: correct `customType` option name

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -718,7 +718,7 @@ export default class Parser extends Stream {
    *
    * @param {Object}   options              a map of options for the added parser
    * @param {RegExp}   options.expression   a regular expression to match the custom header
-   * @param {string}   options.type         the type to register to the output
+   * @param {string}   options.customType   the custom type to register to the output
    * @param {Function} [options.dataParser] function to parse the line into an object
    * @param {boolean}  [options.segment]    should tag data be attached to the segment object
    */


### PR DESCRIPTION
`Parser.addParser` is a pass through to `ParseStream.addParser`, which uses and
documents `customType`. The same is in public docs (README)

Thanks!